### PR TITLE
Unseal ProcessOutput

### DIFF
--- a/os/src/os/SubProcess.scala
+++ b/os/src/os/SubProcess.scala
@@ -298,7 +298,7 @@ object ProcessInput{
   * Represents the configuration of a SubProcess's output or error stream. Can
   * either be [[os.Inherit]], [[os.Pipe]], [[os.Path]] or a [[os.ProcessOutput]]
   */
-sealed trait ProcessOutput{
+trait ProcessOutput{
   def redirectTo: ProcessBuilder.Redirect
   def processOutput(out: => SubProcess.OutputStream): Option[Runnable]
 }


### PR DESCRIPTION
This is useful if you want to customize the thread pulling things out of the subprocess, e.g. making it read the output as lines using a BufferedReader