### PR TITLE
Avoid caching pwd when building native image with Graal

### DIFF
--- a/os/src-jvm/package.scala
+++ b/os/src-jvm/package.scala
@@ -21,7 +21,7 @@ package object os{
   /**
    * The current working directory for this process.
    */
-  val pwd: Path = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
+  def pwd: Path = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
 
   val up: RelPath = RelPath.up
 


### PR DESCRIPTION
Hello,

We have been using sjsonnet together with GraalVM and compiling it down to a native image to get rid of the startup cost of the JVM and the need for a background daemon. One issue we found was that as pwd is defined as a val it will be evaluated during compile time and always return the pwd of when the native image was built. Ex /home/worker/.native-image/machine-id-1f05ee8fbea84a26868d944e6dea086b/session-id-17a2b/server-id-68cf4a1dc9cb59de2...

While there might be similar issues remaining the pwd was what was blocking us. If nothing else this PR highlights the problem if used with Graal or similar.