### PR TITLE
Corrected references to Ammonite

### DIFF
--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -135,17 +135,17 @@ object BasePath {
     s match{
       case "" =>
         fail(
-          "Ammonite-Ops does not allow empty path segments " +
+          "OS-Lib does not allow empty path segments " +
             externalStr + considerStr
         )
       case "." =>
         fail(
-          "Ammonite-Ops does not allow [.] as a path segment " +
+          "OS-Lib does not allow [.] as a path segment " +
             externalStr + considerStr
         )
       case ".." =>
         fail(
-          "Ammonite-Ops does not allow [..] as a path segment " +
+          "OS-Lib does not allow [..] as a path segment " +
             externalStr +
             considerStr +
             "If you want to use the `..` segment manually to represent going up " +

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -12,22 +12,22 @@ object PathTests extends TestSuite{
       test("Transformers"){
         if(Unix()){
           assert(
-            // ammonite.Path to java.nio.file.Path
+            // os.Path to java.nio.file.Path
             (root/'omg).wrapped == Paths.get("/omg"),
 
-            // java.nio.file.Path to ammonite.Path
+            // java.nio.file.Path to os.Path
             root/'omg == Path(Paths.get("/omg")),
             rel/'omg == RelPath(Paths.get("omg")),
             sub/'omg == SubPath(Paths.get("omg")),
 
-            // ammonite.Path to String
+            // os.Path to String
             (root/'omg).toString == "/omg",
             (rel/'omg).toString == "omg",
             (sub/'omg).toString == "omg",
             (up/'omg).toString == "../omg",
             (up/up/'omg).toString == "../../omg",
 
-            // String to ammonite.Path
+            // String to os.Path
             root/'omg == Path("/omg"),
             rel/'omg == RelPath("omg"),
             sub/'omg == SubPath("omg")

--- a/readme.md
+++ b/readme.md
@@ -1708,7 +1708,7 @@ val target = os.pwd/'target
 Should be sufficient for most needs.
 
 Above, we made use of the `os.pwd` built-in path. There are a number of Paths
-built into Ammonite:
+built into OS-Lib:
 
 - `os.pwd`: The current working directory of the process. This can't be changed
   in Java, so if you need another path to work with the convention is to define
@@ -1835,7 +1835,7 @@ representations.
 #### Path Operations
 
 OS-Lib's paths are transparent data-structures, and you can always access the
-segments and ups directly. Nevertheless, Ammonite defines a number of useful
+segments and ups directly. Nevertheless, OS-Lib defines a number of useful
 operations that handle the common cases of dealing with these paths:
 
 In this definition, ThisType represents the same type as the current path; e.g.


### PR DESCRIPTION
This is a very small patch to correct references to Ammonite within the documentation and error messages. Presumably these are a legacy from OS-Lib's origins within Ammonite?