### PR TITLE
Fix for unit-test assuming Unix 'echo' always in /bin/

### DIFF
--- a/os/test/src-jvm/SubprocessTests.scala
+++ b/os/test/src-jvm/SubprocessTests.scala
@@ -83,9 +83,11 @@ object SubprocessTests extends TestSuite{
     }
     test("filebased2"){
       if(Unix()){
+        val possiblePaths = Seq(root / 'bin,
+                                root / 'usr / 'bin).map { pfx => pfx / 'echo }
         val res = proc('which, 'echo).call()
         val echoRoot = Path(res.out.string.trim)
-        assert(echoRoot == root/'bin/'echo)
+        assert(possiblePaths.contains(echoRoot))
 
         assert(proc(echoRoot, 'HELLO).call().out.lines == Seq("HELLO"))
       }


### PR DESCRIPTION
This is a small fix for SubprocessTests, which currently assumes that Unix systems will always have `echo` within `/bin`. The patch allows for systems that have `echo` within `/usr/bin`, and makes it slightly easier to add other paths in future.