### PR TITLE
Buffer output streams in os.write for better performance

### DIFF
--- a/os/src/ReadWriteOps.scala
+++ b/os/src/ReadWriteOps.scala
@@ -10,6 +10,7 @@ import geny.Generator
 
 import scala.io.Codec
 import StandardOpenOption.{CREATE, WRITE}
+import java.io.BufferedOutputStream
 
 /**
   * Write some data to a file. This can be a String, an Array[Byte], or a
@@ -33,9 +34,11 @@ object write{
         else Array(PosixFilePermissions.asFileAttribute(perms.toSet))
       java.nio.file.Files.createFile(target.toNIO, permArray:_*)
     }
-    java.nio.file.Files.newOutputStream(
-      target.toNIO,
-      openOptions.toArray:_*
+    new BufferedOutputStream(
+      java.nio.file.Files.newOutputStream(
+        target.toNIO,
+        openOptions.toArray:_*
+      )
     )
   }
 

--- a/os/src/Source.scala
+++ b/os/src/Source.scala
@@ -8,6 +8,7 @@ import java.nio.channels.{
   SeekableByteChannel,
   WritableByteChannel
 }
+import java.io.BufferedOutputStream
 
 
 /**
@@ -30,14 +31,19 @@ trait Source extends geny.Writable{
       Internals.transfer(inChannel, out)
   }
   def writeBytesTo(out: WritableByteChannel) = getHandle() match{
-    case Left(bs) => bs.writeBytesTo(Channels.newOutputStream(out))
+    case Left(bs) => 
+      val os = new BufferedOutputStream(Channels.newOutputStream(out))
+      bs.writeBytesTo(os)
+      os.flush()
 
     case Right(channel) =>
       (channel, out) match {
         case (src: FileChannel, dest) => src.transferTo(0, Long.MaxValue, dest)
         case (src, dest: FileChannel) => dest.transferFrom(dest, 0, Long.MaxValue)
         case (src, dest) =>
-          Internals.transfer(Channels.newInputStream(src), Channels.newOutputStream(dest))
+          val os = new BufferedOutputStream(Channels.newOutputStream(dest))
+          Internals.transfer(Channels.newInputStream(src), os)
+          os.flush()
       }
 
   }


### PR DESCRIPTION
This PR requires https://github.com/lihaoyi/geny/pull/11 to get the performance gains

`os.write` has poor performance when writing long iterable sequences eg

```scala
val lines = Iterator.range(0,1000000).map{x => x.toString + "\n"}.toSeq
os.write.over(os.pwd/"big.txt", lines)
```

which is about 10-30x slower than

```scala
os.write.over(os.pwd/"big.txt", lines.mkString("\n"))
```
This is due to repeated flushing of the main `OutputStream` in geny `Writable` but also the lack of buffering in `os.write`.

Here I buffer the output stream and also flush it at the end to ensure a full write. I elected not to close the output stream because that would also close the downstream classes which may not be desirable.
