### PR TITLE
Add `using` where it is needed

### DIFF
--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -477,8 +477,8 @@ object Path extends PathMacros {
     val f = implicitly[PathConvertible[T]].apply(f0)
     if (f.subpath(0, 1).toString != "~") if (base == null) Path(f0) else Path(f0, base)
     else {
-      Path(System.getProperty("user.home"))(PathConvertible.StringConvertible) /
-        RelPath(f.subpath(0, 1).relativize(f))(PathConvertible.NioPathConvertible)
+      Path(System.getProperty("user.home"))(using PathConvertible.StringConvertible) /
+        RelPath(f.subpath(0, 1).relativize(f))(using PathConvertible.NioPathConvertible)
     }
   }
 


### PR DESCRIPTION
For CB, we should add `using` clause here since starting from `3.5.0`, they desugar to contextual parameters instead of implicit parameters.