### PR TITLE
Trial build with Scala Native 0.5.10-SNAPSHOT

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -236,7 +236,15 @@ object os extends Module {
 
   object native extends Cross[OsNativeModule](scalaVersions)
   trait OsNativeModule extends OsModule with ScalaNativeModule {
-    def scalaNativeVersion = "0.5.9"
+
+    def repositoriesTask = Task.Anon { super.repositoriesTask() ++ Seq(
+        coursier.maven.MavenRepository(
+          "https://central.sonatype.com/repository/maven-snapshots/"
+        )
+       )
+     }
+
+    def scalaNativeVersion = "0.5.10-20260109-81a2fad-SNAPSHOT"
     
     // Configurable native mode for debugging/performance testing
     def nativeMode = sys.props.get("native.mode") match {


### PR DESCRIPTION
Run the os-lib CI using a Scala Native 0.5.10-SNAPSHOT.

This snapshot contains a Scala Native PR which better handles Java `Process` invocations.
`os-lib` `SubprocessTests` exercises that code path.

Running the `SubprocessTests` with SN 0.5.9 for a number of iterations ranging
from a few tens to a few hundred rapidly sequential iterations fails by a process
not terminating; sometimes by being stuck in a tight CPU loop and sometimes
by a zero-CPU hang.  Either are not desirable behavior.  

Doing the same exercise using various JVM versions succeed at 4_000+ iterations,
stopping iteration for lack of patience.

A private development version of the SN changes ran the exercise many times.
The highest was at 10_000 iterations.

This PR will do only one iteration.

<hr>

2026-01-11 14:00 UTC

An private sandbox overnight run of `SubprocessTests`  succeed at 4000 iterations
before its expected exit.