### PR TITLE
Make `os.Path.pathSerializer` configurable via an env var `OS_LIB_PATH_RELATIVIZER_BASE`

### DIFF
--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -448,7 +448,44 @@ object Path extends PathMacros {
     def deserialize(s: java.net.URI): java.nio.file.Path
   }
   @experimental val pathSerializer = new DynamicVariable[Serializer](defaultPathSerializer)
-  @experimental object defaultPathSerializer extends Serializer {
+  @experimental lazy val defaultPathSerializer: Serializer = {
+    val maybeBase = Option(System.getenv("OS_LIB_PATH_RELATIVIZER_BASE")).filter(_.nonEmpty)
+    maybeBase match {
+      case Some(base0) =>
+        pathRelativizerSerializer(Path(base0))
+      case None =>
+        rawPathSerializer
+    }
+  }
+
+  @experimental def pathRelativizerSerializer(base: os.Path): Serializer = new Serializer {
+    private def serializeRelative(p: os.Path): Option[java.nio.file.Path] = {
+      if (p.fileSystem == base.fileSystem && p.startsWith(base)) Some(p.relativeTo(base).toNIO)
+      else None
+    }
+    private def deserializeRelative(p: java.nio.file.Path): java.nio.file.Path = {
+      if (p.isAbsolute || Path.driveRelative(p)) p
+      else base.wrapped.resolve(p.toString).normalize()
+    }
+    def serializeString(p: os.Path): String =
+      serializeRelative(p).getOrElse(p.wrapped).toString
+    def serializeFile(p: os.Path): java.io.File =
+      serializeRelative(p).getOrElse(p.wrapped).toFile
+    def serializePath(p: os.Path): java.nio.file.Path =
+      serializeRelative(p).getOrElse(p.wrapped)
+    def deserialize(s: String): java.nio.file.Path = deserializeRelative(Paths.get(s))
+    def deserialize(s: java.io.File): java.nio.file.Path = deserializeRelative(Paths.get(s.getPath))
+    def deserialize(s: java.nio.file.Path): java.nio.file.Path = deserializeRelative(s)
+    def deserialize(s: java.net.URI): java.nio.file.Path = s.getScheme() match {
+      case "file" => deserializeRelative(Paths.get(s))
+      case uriType =>
+        throw new IllegalArgumentException(
+          s"""os.Path can only be created from a "file" URI scheme, but found "${uriType}""""
+        )
+    }
+  }
+
+  private object rawPathSerializer extends Serializer {
     def serializeString(p: os.Path): String = p.wrapped.toString
     def serializeFile(p: os.Path): java.io.File = p.wrapped.toFile
     def serializePath(p: os.Path): java.nio.file.Path = p.wrapped

--- a/os/src/Path.scala
+++ b/os/src/Path.scala
@@ -470,7 +470,7 @@ object Path extends PathMacros {
     def serializeString(p: os.Path): String =
       serializeRelative(p).getOrElse(p.wrapped).toString
     def serializeFile(p: os.Path): java.io.File =
-      serializeRelative(p).getOrElse(p.wrapped).toFile
+      new java.io.File(serializeString(p))
     def serializePath(p: os.Path): java.nio.file.Path =
       serializeRelative(p).getOrElse(p.wrapped)
     def deserialize(s: String): java.nio.file.Path = deserializeRelative(Paths.get(s))

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -574,6 +574,25 @@ object PathTests extends TestSuite {
 
       assert(x / "hello" == y)
     }
+    test("pathRelativizerSerializer") {
+      val base = os.pwd / "base"
+      val serializer = os.Path.pathRelativizerSerializer(base)
+      os.Path.pathSerializer.withValue(serializer) {
+        val inBase = base / "foo" / "bar"
+        val outside = os.pwd / "outside"
+
+        assert(inBase.toString == "foo/bar")
+        assert(inBase.toNIO == java.nio.file.Paths.get("foo/bar"))
+        assert(inBase.toIO == new java.io.File("foo/bar"))
+
+        assert(os.Path("foo/bar") == inBase)
+        assert(os.Path(java.nio.file.Paths.get("foo/bar")) == inBase)
+        assert(os.Path(new java.io.File("foo/bar")) == inBase)
+
+        assert(outside.toString == outside.wrapped.toString)
+        assert(outside.toNIO == outside.wrapped)
+      }
+    }
   }
   // compare absolute paths
   def sameFile(a: java.nio.file.Path, b: java.nio.file.Path): Boolean = {

--- a/os/test/src/PathTests.scala
+++ b/os/test/src/PathTests.scala
@@ -575,22 +575,25 @@ object PathTests extends TestSuite {
       assert(x / "hello" == y)
     }
     test("pathRelativizerSerializer") {
+      def check(name: String)(cond: => Boolean): Unit = {
+        if (!cond) throw new java.lang.AssertionError(s"check failed: $name")
+      }
       val base = os.pwd / "base"
       val serializer = os.Path.pathRelativizerSerializer(base)
       os.Path.pathSerializer.withValue(serializer) {
         val inBase = base / "foo" / "bar"
         val outside = os.pwd / "outside"
 
-        assert(inBase.toString == "foo/bar")
-        assert(inBase.toNIO == java.nio.file.Paths.get("foo/bar"))
-        assert(inBase.toIO == new java.io.File("foo/bar"))
+        check("serialize string in base")(inBase.toString == "foo/bar")
+        check("serialize nio in base")(inBase.toNIO == java.nio.file.Paths.get("foo/bar"))
+        check("serialize file in base")(inBase.toIO.getPath == new java.io.File("foo/bar").getPath)
 
-        assert(os.Path("foo/bar") == inBase)
-        assert(os.Path(java.nio.file.Paths.get("foo/bar")) == inBase)
-        assert(os.Path(new java.io.File("foo/bar")) == inBase)
+        check("deserialize string relative")(os.Path("foo/bar") == inBase)
+        check("deserialize nio relative")(os.Path(java.nio.file.Paths.get("foo/bar")) == inBase)
+        check("deserialize file relative")(os.Path(new java.io.File("foo/bar")) == inBase)
 
-        assert(outside.toString == outside.wrapped.toString)
-        assert(outside.toNIO == outside.wrapped)
+        check("serialize string outside base")(outside.toString == outside.wrapped.toString)
+        check("serialize nio outside base")(outside.toNIO == outside.wrapped)
       }
     }
   }


### PR DESCRIPTION
This makes configuration a lot more reliable than doing it via a `DynamicVariable`, since it automatically propagates across classloader and subprocess boundaries