### PR TITLE
Modify sentinelFiles to follow links in provided roots

### DIFF
--- a/os/watch/src/package.scala
+++ b/os/watch/src/package.scala
@@ -56,7 +56,11 @@ package object watch {
       throw new IllegalArgumentException(errors.mkString("\n"))
     }
 
-    val sentinelFiles = roots.iterator.map(_ / s".os-lib-watch-sentinel-${UUID.randomUUID()}").toSet
+    val sentinelFiles = 
+      roots
+        .iterator
+        .flatMap(os.followLink(_).map(_ / s".os-lib-watch-sentinel-${UUID.randomUUID()}"))
+        .toSet
 
     @volatile var customOnEvent: OnEvent = onEvent
     // Needed because the function passed to the watcher implementation is stable and we need to change it


### PR DESCRIPTION
This makes the sentinel file paths match the paths fed to the `onEvent` handler (which are the real paths of the roots). Before this fix, watching directories under the `/tmp` directory on maxOS didn't work since `/tmp` is a link to `/private/tmp`, hindering the sentinel files from being matched correctly during startup.